### PR TITLE
[GRAP-13] Implement AST Tree

### DIFF
--- a/Build
+++ b/Build
@@ -8,6 +8,7 @@ cd build
 
 LD_LIBRARY_PATH=$PWD/build/Frontend/src/:${LD_LIBRARY_PATH}
 LD_LIBRARY_PATH=$PWD/build/Backend/src/:${LD_LIBRARY_PATH}
+LD_LIBRARY_PATH=$PWD/build/Common/AST/src/:${LD_LIBRARY_PATH}
 export LD_LIBRARY_PATH
 
 qmake ../Graph.pro

--- a/Common/AST/AST.pro
+++ b/Common/AST/AST.pro
@@ -1,0 +1,6 @@
+# AST
+TEMPLATE = subdirs
+
+# Add the subdirectories for the sources and tests to SUBDIRS
+SUBDIRS += src/ASTSRC.pro \
+           test/ASTTest.pro

--- a/Common/AST/src/AST.cpp
+++ b/Common/AST/src/AST.cpp
@@ -1,0 +1,100 @@
+#include "AST.hpp"
+
+namespace AST
+{
+
+ASTTree::ASTTree(Node* root_)
+{
+    root = root_;
+}
+
+ASTTree::~ASTTree()
+{
+    std::vector<Node*> elements;
+    for (auto it = begin(); it != end(); ++it)
+    {
+        elements.push_back(it.get());
+    }
+
+    for (auto* elem : elements)
+    {
+        elem->destroy();
+    }
+}
+
+ASTTree::DSFIterator ASTTree::begin()
+{
+    return ASTTree::DSFIterator(root);
+}
+
+ASTTree::DSFIterator ASTTree::end()
+{
+    return ASTTree::DSFIterator();
+}
+
+ASTTree::DSFIterator ASTTree::insert(Node* newNode, DSFIterator it)
+{
+    if (newNode == nullptr) { throw std::runtime_error("Insert nullptr, bug!?"); }
+
+    if (!root)
+    {
+        if (it != begin()) { throw std::runtime_error("Insert in empty tree, but not to begin, bug!?"); }
+        root = newNode;
+        return begin();
+    }
+
+    it->addChild(newNode);
+    return DSFIterator{newNode};
+}
+
+ASTTree::DSFIterator::DSFIterator(Node* root)
+{
+    if (root) { toVisit.push(root); }
+}
+
+ASTTree::DSFIterator& ASTTree::DSFIterator::operator++()
+{
+    if (!toVisit.empty())
+    {
+        Node* current = toVisit.top();
+        toVisit.pop();
+
+        for (auto it = current->childNodes.rbegin(); it != current->childNodes.rend(); ++it)
+        {
+            toVisit.push(*it);
+        }
+    }
+
+    return *this;
+}
+
+Node* ASTTree::DSFIterator::get() const noexcept
+{
+    return toVisit.empty() ? nullptr : toVisit.top();
+}
+
+Node& ASTTree::DSFIterator::operator*() const
+{
+    if (toVisit.empty()) { throw std::runtime_error("Dereference empty iter, bug!?"); }
+    return *toVisit.top();
+}
+
+Node* ASTTree::DSFIterator::operator->() const
+{
+    if (toVisit.empty()) { throw std::runtime_error("Dereference empty iter, bug!?"); }
+    return toVisit.top();
+}
+
+bool ASTTree::DSFIterator::operator!=(DSFIterator const& other) const noexcept
+{
+    if (toVisit.empty() && other.toVisit.empty()) { return false; }
+    if (toVisit.empty() != other.toVisit.empty()) { return true; }
+    return toVisit.top() != other.toVisit.top();
+}
+
+bool ASTTree::DSFIterator::operator==(DSFIterator const& other) const noexcept
+{
+    return !(*this != other);
+}
+
+} // namespace AST

--- a/Common/AST/src/AST.hpp
+++ b/Common/AST/src/AST.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <stack>
+
+#include "Node.hpp"
+
+namespace AST
+{
+
+class ASTTree
+{
+public:
+    ASTTree(Node* root = nullptr);
+    ~ASTTree();
+
+    class DSFIterator
+    {
+    public:
+        DSFIterator() = default;
+        explicit DSFIterator(Node* root);
+
+        bool operator!=(DSFIterator const&) const noexcept;
+        bool operator==(DSFIterator const&) const noexcept;
+
+        Node* get() const noexcept;
+        DSFIterator& operator++();
+        Node& operator*() const;
+        Node* operator->() const;
+
+    private:
+        std::stack<Node*> toVisit;
+    };
+
+    DSFIterator begin();
+    DSFIterator end();
+    DSFIterator insert(Node* newNode, DSFIterator it);
+
+private:
+    Node* root;
+};
+
+} // namespace AST

--- a/Common/AST/src/ASTSRC.pro
+++ b/Common/AST/src/ASTSRC.pro
@@ -1,0 +1,18 @@
+# AST lib
+TEMPLATE = lib
+TARGET = AST
+
+QT += core
+
+CONFIG += c++17
+CONFIG += plugin
+
+# Build dirs
+OBJECTS_DIR = objects
+MOC_DIR     = objects
+UI_DIR      = objects
+RCC_DIR     = objects
+
+SOURCES += AST.cpp
+
+HEADERS += AST.hpp

--- a/Common/AST/src/Node.hpp
+++ b/Common/AST/src/Node.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <stdexcept>
+
+namespace AST
+{
+
+struct Node
+{
+    Node(std::string const& value_) : value{value_} {}
+    void destroy() { delete this; } // instead of the destructor
+
+    std::string getValue() const noexcept { return value; }
+    void addChild(Node* child)
+    {
+        if (child == nullptr) { throw std::runtime_error("Add child, but nullptr, bug!?"); }
+        childNodes.push_back(child);
+    }
+
+    std::string value;
+    std::vector<Node*> childNodes;
+
+private:
+    ~Node() = default; // Making it impossible to create on the stack
+};
+
+} // namespace AST

--- a/Common/AST/test/ASTTest.pro
+++ b/Common/AST/test/ASTTest.pro
@@ -1,0 +1,19 @@
+# AST's tests
+TEMPLATE = app
+TARGET = ASTTest
+
+# Build dirs
+OBJECTS_DIR = objects
+MOC_DIR     = objects
+UI_DIR      = objects
+RCC_DIR     = objects
+
+LIBS += -L$$PWD/../../../build/Common/AST/src -lAST
+
+QT += testlib core
+
+SOURCES += test.cpp
+
+HEADERS += ../src/AST.hpp
+
+INCLUDEPATH +=../src

--- a/Common/AST/test/test.cpp
+++ b/Common/AST/test/test.cpp
@@ -1,0 +1,259 @@
+#include <QtTest/QtTest>
+#include <stdexcept>
+
+#include "AST.hpp"
+
+using namespace AST;
+
+class TestClass : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void test_initializeTree();
+    void test_insertToBeginTree();
+    void test_insertToAnyNodeTree();
+    void test_rangeForTree();
+    void test_TreeIterCompare();
+    void test_failureCaseTree();
+};
+
+void TestClass::test_initializeTree()
+{
+    Node* root = new Node("PROGRAM");
+    ASTTree tree(root);
+
+    auto it = tree.begin();
+    QVERIFY(it != tree.end());
+    QVERIFY(it->getValue() == "PROGRAM");
+}
+
+void TestClass::test_insertToBeginTree()
+{
+    ASTTree tree;
+
+    { // insert first node to empty tree
+        Node* node = new Node("PROGRAM");
+        // auto it = tree.begin();
+        tree.insert(node, tree.begin());
+
+        auto it = tree.begin();
+        QVERIFY(it != tree.end());
+        QVERIFY(it->getValue() == "PROGRAM");
+
+        ++it;
+
+        QVERIFY(it == tree.end());
+    }
+
+    { // insert second node to tree
+        Node* node = new Node("STARTGRAPH");
+        tree.insert(node, tree.begin());
+
+        auto it = tree.begin();
+        QVERIFY(it != tree.end());
+        QVERIFY(it->getValue() == "PROGRAM");
+
+        ++it;
+
+        QVERIFY(it != tree.end());
+        QVERIFY(it->getValue() == "STARTGRAPH");
+
+        ++it;
+
+        QVERIFY(it == tree.end());
+    }
+
+    { // insert third node to tree
+        Node* node = new Node("ENDGRAPH");
+        tree.insert(node, tree.begin());
+
+        auto it = tree.begin();
+        QVERIFY(it != tree.end());
+        QVERIFY(it->getValue() == "PROGRAM");
+
+        ++it;
+
+        QVERIFY(it != tree.end());
+        QVERIFY(it->getValue() == "STARTGRAPH");
+
+        ++it;
+
+        QVERIFY(it != tree.end());
+        QVERIFY(it->getValue() == "ENDGRAPH");
+
+        ++it;
+
+        QVERIFY(it == tree.end());
+    }
+}
+
+void TestClass::test_insertToAnyNodeTree()
+{
+    Node* root = new Node("PROGRAM");
+    ASTTree tree(root);
+
+    // insert after PROGRAM
+    Node* nodeStatement = new Node("STATEMENT");
+    auto itStatement = tree.insert(nodeStatement, tree.begin());
+    QVERIFY(itStatement != tree.end());
+    QVERIFY(itStatement->getValue() == "STATEMENT");
+
+    // insert after STATEMENT
+    Node* nodeRelation = new Node("RELATION");
+    auto itRelation = tree.insert(nodeRelation, itStatement);
+    QVERIFY(itRelation != tree.end());
+    QVERIFY(itRelation->getValue() == "RELATION");
+
+    // insert after RELATION
+    Node* nodePointer = new Node("<--");
+    auto itPointer = tree.insert(nodePointer, itRelation);
+    QVERIFY(itPointer != tree.end());
+    QVERIFY(itPointer->getValue() == "<--");
+
+    { // check tree sturcture
+        auto it = tree.begin();
+        QVERIFY(it != tree.end());
+        QVERIFY(it->getValue() == "PROGRAM");
+
+        ++it;
+
+        QVERIFY(it != tree.end());
+        QVERIFY(it->getValue() == "STATEMENT");
+
+        ++it;
+
+        QVERIFY(it != tree.end());
+        QVERIFY(it->getValue() == "RELATION");
+
+        ++it;
+
+        QVERIFY(it != tree.end());
+        QVERIFY(it->getValue() == "<--");
+
+        ++it;
+
+        QVERIFY(it == tree.end());
+    }
+
+    // insert after PROGRAM
+    Node* nodeStatement2 = new Node("STATEMENT");
+    auto itStatement2 = tree.insert(nodeStatement2, tree.begin());
+    QVERIFY(itStatement2 != tree.end());
+    QVERIFY(itStatement2->getValue() == "STATEMENT");
+
+    // insert after RELATION
+    Node* nodeID = new Node("ID");
+    auto itID = tree.insert(nodeID, itRelation);
+    QVERIFY(itID != tree.end());
+    QVERIFY(itID->getValue() == "ID");
+
+    { // check tree sturcture
+        auto it = tree.begin();
+        QVERIFY(it != tree.end());
+        QVERIFY(it->getValue() == "PROGRAM");
+
+        ++it;
+
+        QVERIFY(it != tree.end());
+        QVERIFY(it->getValue() == "STATEMENT");
+
+        ++it;
+
+        QVERIFY(it != tree.end());
+        QVERIFY(it->getValue() == "RELATION");
+
+        ++it;
+
+        QVERIFY(it != tree.end());
+        QVERIFY(it->getValue() == "<--");
+
+        ++it;
+
+        QVERIFY(it != tree.end());
+        QVERIFY(it->getValue() == "ID");
+
+        ++it;
+
+        QVERIFY(it != tree.end());
+        QVERIFY(it->getValue() == "STATEMENT");
+
+        ++it;
+
+        QVERIFY(it == tree.end());
+    }
+}
+
+void TestClass::test_rangeForTree()
+{
+    Node* root = new Node("PROGRAM");
+    ASTTree tree(root);
+
+    // insert after PROGRAM
+    Node* nodeStatement = new Node("STATEMENT");
+    auto itStatement = tree.insert(nodeStatement, tree.begin());
+    QVERIFY(itStatement != tree.end());
+    QVERIFY(itStatement->getValue() == "STATEMENT");
+
+    // insert after STATEMENT
+    Node* nodeRelation = new Node("RELATION");
+    auto itRelation = tree.insert(nodeRelation, itStatement);
+    QVERIFY(itRelation != tree.end());
+    QVERIFY(itRelation->getValue() == "RELATION");
+
+    // insert after RELATION
+    Node* nodePointer = new Node("<--");
+    auto itPointer = tree.insert(nodePointer, itRelation);
+    QVERIFY(itPointer != tree.end());
+    QVERIFY(itPointer->getValue() == "<--");
+
+    int idx = 0;
+    for (auto it = tree.begin(); it != tree.end(); ++it, ++idx)
+    {
+        if (idx == 0) { QVERIFY(it->getValue() == "PROGRAM"); }
+        if (idx == 1) { QVERIFY(it->getValue() == "STATEMENT"); }
+        if (idx == 2) { QVERIFY(it->getValue() == "RELATION"); }
+        if (idx == 3) { QVERIFY(it->getValue() == "<--"); }
+    }
+}
+
+void TestClass::test_TreeIterCompare()
+{
+    {
+        Node* root = new Node("PROGRAM");
+        ASTTree tree(root);
+
+        QVERIFY(tree.begin() != tree.end());
+        QVERIFY(++tree.begin() == tree.end());
+    }
+
+    {
+        ASTTree tree;
+        QVERIFY(tree.begin() == tree.end());
+
+        Node* root = new Node("PROGRAM");
+        auto it = tree.insert(root, tree.begin());
+
+        QVERIFY(tree.begin() != tree.end());
+        QVERIFY(tree.begin() == it);
+
+        QVERIFY(++tree.begin() == tree.end());
+        QVERIFY(it != tree.end());
+        QVERIFY(++it == tree.end());
+    }
+}
+
+void TestClass::test_failureCaseTree()
+{
+    Node* root = new Node("PROGRAM");
+    ASTTree tree(root);
+
+    QVERIFY_EXCEPTION_THROWN(tree.insert(nullptr, tree.begin()), std::runtime_error);
+
+    auto it = tree.end();
+    QVERIFY_EXCEPTION_THROWN(*it, std::runtime_error);
+    QVERIFY_EXCEPTION_THROWN(it->getValue(), std::runtime_error);
+}
+
+QTEST_GUILESS_MAIN(TestClass)
+#include "test.moc"

--- a/Common/Common.pro
+++ b/Common/Common.pro
@@ -2,6 +2,7 @@
 TEMPLATE = subdirs
 
 # Add the subdirectories for the common structs
-# SUBDIRS += Logger # TODO: implement
+# SUBDIRS += Logger # TODO: uncommend during GRAP-38
+SUBDIRS += AST
 
 CONFIG += ordered

--- a/runApp
+++ b/runApp
@@ -2,6 +2,7 @@
 
 LD_LIBRARY_PATH=$PWD/build/Frontend/src/:${LD_LIBRARY_PATH}
 LD_LIBRARY_PATH=$PWD/build/Backend/src/:${LD_LIBRARY_PATH}
+LD_LIBRARY_PATH=$PWD/build/Common/AST/src/:${LD_LIBRARY_PATH}
 export LD_LIBRARY_PATH
 
 ./build/App/Graph

--- a/runTest
+++ b/runTest
@@ -2,6 +2,7 @@
 
 LD_LIBRARY_PATH=$PWD/build/Frontend/src/:${LD_LIBRARY_PATH}
 LD_LIBRARY_PATH=$PWD/build/Backend/src/:${LD_LIBRARY_PATH}
+LD_LIBRARY_PATH=$PWD/build/Common/AST/src/:${LD_LIBRARY_PATH}
 export LD_LIBRARY_PATH
 
 # check choosen component to build
@@ -9,8 +10,11 @@ if [ "$1" = "--Front" ]; then
     ./build/Frontend/test/FrontendTest
 elif [ "$1" = "--Backend" ]; then
     ./build/Backend/test/BackendTest
+elif [ "$1" = "--Common" ]; then
+    ./build/Common/AST/test/ASTTest
 else
     # default - run all tests
     ./build/Frontend/test/FrontendTest
     ./build/Backend/test/BackendTest
+    ./build/Common/AST/test/ASTTest
 fi


### PR DESCRIPTION
Добавил класс ASTTree вместе с вспомогающими классами Node и DFSIterator

Дерево хранить указатель на рутовый узел. Рутовый узел может быть только один (ну это же дерево). По дереву можно перемещаться с помощью DFSIterator, который обходит дерево вглубину. Для перехода на следующий элемент нужно инкрементировать итератор, а для обращения к полям - разыменовать его. Так как наше дерево является B деревом, то для обхода в глубину итератор хранить стек узлов, которые ему предстоит посетить, а если этот стек пуст, то это эквивалентно завершению обхода или end(). Реализация не претендует на STL стиль или какиенить exception safety. Также из дерева нельзя удалять элементы, но для наших задач, ему надо только уметь делать обход в глубину и добавлять новые элементы. Кстати, добавление новых элементов можно делать методом instert, где первый параметр - это узел, который нужно вставить, а второй - итератор, после которого (т е ребёнком которого) нужно вставить. Пример использования можно посмотреть в тестах.

Что касаемо структуры Node, то мне кажется, что ей достаточно хранить строку, которая будет обозначать терминал или нетерминал или даже числа. Это очень удобно хранить и для представления. А уже при разборе (в трансляторе или ретрансляторе) нужно будет делать if - else на каждый интересущий нас терминал или нетерминал (там же переводить числа функцией to_string, например)